### PR TITLE
[Feat] 설문 연계 API 구현, user APi 구현  및 alert-summary 관련 select 페이지 추가

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,8 +1,13 @@
 import {
   HourlyWeatherResponse,
+  Survey,
   TodayBannerResponse,
-  TodaySummaryResponse
+  TodaySummaryResponse,
+  UserReponse
 } from "./type";
+
+import { PeriodValueType } from "@/types/survey";
+import { StorageKey } from "@/constants/storage";
 
 export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_MOCKING === "enabled"
@@ -30,5 +35,48 @@ export const getHourlyWeathers = async (lat: number, lon: number) => {
     `${API_BASE_URL}/weathers/hourly?lat=${lat}&lon=${lon}&offset=24`
   );
   const data: HourlyWeatherResponse = await res.json();
+  return data;
+};
+
+export const createUser = async (survey: Survey, fcmToken: string) => {
+  const res = await fetch(`${API_BASE_URL}/users`, {
+    method: "POST",
+    body: JSON.stringify({
+      fcmToken,
+      survey
+    }),
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+  const data: UserReponse = await res.json();
+  return data;
+};
+
+export const updateUserToken = async (fcmToken: string, userId: string) => {
+  const res = await fetch(`${API_BASE_URL}/users`, {
+    method: "PATCH",
+    body: JSON.stringify({ fcmToken }),
+    headers: {
+      Authorization: userId,
+      "Content-Type": "application/json"
+    }
+  });
+  const data: UserReponse = await res.json();
+  return data;
+};
+
+export const updateSurvey = async (survey: Survey, userId: string) => {
+  const res = await fetch(`${API_BASE_URL}/surveys`, {
+    method: "PUT",
+    body: JSON.stringify({
+      survey
+    }),
+    headers: {
+      Authorization: userId,
+      "Content-Type": "application/json"
+    }
+  });
+  const data: Survey = await res.json();
   return data;
 };

--- a/src/api/type.ts
+++ b/src/api/type.ts
@@ -1,3 +1,5 @@
+import { PeriodValueType } from "@/types/survey";
+
 export interface TodayBannerResponse {
   desc: string;
   title: string;
@@ -37,4 +39,17 @@ export interface HourlyWeatherResponse {
     pop: number;
     clothes: Clothes[];
   }[];
+}
+
+export interface UserReponse {
+  id: number;
+  fcmToken: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Survey {
+  alertBeforeRain: number;
+  timePeriods: PeriodValueType[];
+  summaryAlertTime: null | number;
 }

--- a/src/app/content/page.tsx
+++ b/src/app/content/page.tsx
@@ -27,7 +27,7 @@ const Content = () => {
         </div>
         <div className="mt-22pxr">
           <Link
-            href="/survey"
+            href="/survey/alert-before"
             className="text-light-secondary text-15pxr font-regular"
           >
             알람 설정

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from "react";
 
 import FadeTitle from "@/components/FadeTitle";
 import { StorageKey } from "@/constants/storage";
+import { TRANSITION_DURATIN } from "@/constants/duration";
 import { useRouter } from "next/navigation";
 
 export default function Home() {
@@ -11,6 +12,7 @@ export default function Home() {
 
   const isFirstUser = useMemo(() => {
     if (typeof window === "undefined") return;
+
     return localStorage.getItem(StorageKey.UserId) === null;
   }, []);
 
@@ -18,9 +20,8 @@ export default function Home() {
     if (isFirstUser === undefined) return;
 
     const timeoutID = setTimeout(() => {
-      // router.push(isFirstUser ? "/onboarding" : "/content");
-      router.push("/content");
-    }, 1500);
+      router.push(isFirstUser ? "/onboarding" : "/content");
+    }, 1000);
 
     return () => {
       clearTimeout(timeoutID);

--- a/src/app/survey/alert-before/page.tsx
+++ b/src/app/survey/alert-before/page.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from "react";
-import { useAtom, useSetAtom } from "jotai";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import BackHeader from "@/components/header/BackHeader";
 import FadeTitle from "@/components/FadeTitle";
@@ -16,20 +9,29 @@ import ProgressBar from "@/components/ProgressBar";
 import TimeInput from "@/components/input/TimeInput";
 import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import { surveyAtom } from "@/atom/survey";
+import { useAtom } from "jotai";
 import useFocused from "@/hooks/useFocused";
 import useNextSurvey from "@/hooks/survey/useNextSurvey";
-import { useRouter } from "next/navigation";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
-import useVisualViewportHeight from "@/hooks/useVisualViewportHeight";
 
 const AlertBefore = () => {
-  const viewportHeight = useVisualViewportHeight();
-  const router = useRouter();
   const hourRef = useRef<HTMLInputElement>(null);
   const minuteRef = useRef<HTMLInputElement>(null);
   const [isDone, setIsDone] = useState(false);
 
-  const setSurvey = useSetAtom(surveyAtom);
+  const [{ alertBeforeRain }, setSurvey] = useAtom(surveyAtom);
+
+  useEffect(() => {
+    if (!alertBeforeRain || !hourRef.current || !minuteRef.current) return;
+
+    const hour = Math.floor(alertBeforeRain / 60);
+    const minute = alertBeforeRain % 60;
+
+    hourRef.current.value = String(hour);
+    minuteRef.current.value = String(minute);
+
+    setIsDone(hour + minute > 0);
+  }, [alertBeforeRain, hourRef, minuteRef]);
 
   const { isFocused: isHourFocused, bind: hourBind } = useFocused();
   const { isFocused: isMinuteFocused, bind: minuteBind } = useFocused();
@@ -49,8 +51,32 @@ const AlertBefore = () => {
   }, [isFocused]);
 
   const percent = useSurveyProgressPercent(isDone);
-  const { goToNextPage } = useNextSurvey();
 
+  const [shouldTransition, setShouldTransition] = useState(false);
+
+  useEffect(() => {
+    if (isDone) return;
+
+    const timeoutID = setTimeout(() => {
+      setShouldTransition(true);
+    }, 500);
+    return () => {
+      clearTimeout(timeoutID);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isDone) return;
+
+    const timeoutID = setTimeout(() => {
+      setShouldTransition(false);
+    }, 200);
+    return () => {
+      clearTimeout(timeoutID);
+    };
+  }, [isDone]);
+
+  const { goToNextPage } = useNextSurvey();
   const onClickNext = () => {
     const hour = Number(hourRef.current?.value);
     const minute = Number(minuteRef.current?.value);
@@ -68,7 +94,7 @@ const AlertBefore = () => {
       </section>
 
       <TransitionTightSection
-        shouldTransition={isFocused}
+        shouldTransition={shouldTransition}
         Top={<FadeTitle text="미리 알려 드릴게요" />}
         Bottom={
           <TimeInput

--- a/src/app/survey/alert-before/page.tsx
+++ b/src/app/survey/alert-before/page.tsx
@@ -17,6 +17,7 @@ import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import { surveyAtom } from "@/atom/survey";
 import { useAtom } from "jotai";
 import useFocused from "@/hooks/useFocused";
+import useNextSurvey from "@/hooks/survey/useNextSurvey";
 import { useRouter } from "next/navigation";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
@@ -55,10 +56,11 @@ const AlertBefore = () => {
     setShouldTransition(isFocused);
   }, [isFocused]);
 
+  const { goToNextPage } = useNextSurvey();
   const onClickNext = useCallback(() => {
     setSurvey({ alertBeforeRain: time });
-    router.push("/survey/alert-summary/agreed");
-  }, [time]);
+    goToNextPage();
+  }, [time, goToNextPage]);
 
   const percent = useSurveyProgressPercent(isDone);
 

--- a/src/app/survey/alert-before/page.tsx
+++ b/src/app/survey/alert-before/page.tsx
@@ -12,17 +12,16 @@ import BackHeader from "@/components/header/BackHeader";
 import FadeTitle from "@/components/FadeTitle";
 import FixedBottomBar from "@/components/bottombar/FixedBottomBar";
 import ProgressBar from "@/components/ProgressBar";
+import { TRANSITION_DURATIN } from "@/constants/duration";
 import TimeInput from "@/components/input/TimeInput";
 import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import { surveyAtom } from "@/atom/survey";
 import { useAtom } from "jotai";
 import useFocused from "@/hooks/useFocused";
 import useNextSurvey from "@/hooks/survey/useNextSurvey";
-import { useRouter } from "next/navigation";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
 const AlertBefore = () => {
-  const router = useRouter();
   const hourRef = useRef<HTMLInputElement>(null);
   const minuteRef = useRef<HTMLInputElement>(null);
 
@@ -46,7 +45,7 @@ const AlertBefore = () => {
 
     const timeoutID = setTimeout(() => {
       setShouldTransition(true);
-    }, 500);
+    }, TRANSITION_DURATIN);
     return () => {
       clearTimeout(timeoutID);
     };

--- a/src/app/survey/alert-before/page.tsx
+++ b/src/app/survey/alert-before/page.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 
 import BackHeader from "@/components/header/BackHeader";
 import FadeTitle from "@/components/FadeTitle";
@@ -11,27 +17,17 @@ import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import { surveyAtom } from "@/atom/survey";
 import { useAtom } from "jotai";
 import useFocused from "@/hooks/useFocused";
-import useNextSurvey from "@/hooks/survey/useNextSurvey";
+import { useRouter } from "next/navigation";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
 const AlertBefore = () => {
+  const router = useRouter();
   const hourRef = useRef<HTMLInputElement>(null);
   const minuteRef = useRef<HTMLInputElement>(null);
-  const [isDone, setIsDone] = useState(false);
 
   const [{ alertBeforeRain }, setSurvey] = useAtom(surveyAtom);
 
-  useEffect(() => {
-    if (!alertBeforeRain || !hourRef.current || !minuteRef.current) return;
-
-    const hour = Math.floor(alertBeforeRain / 60);
-    const minute = alertBeforeRain % 60;
-
-    hourRef.current.value = String(hour);
-    minuteRef.current.value = String(minute);
-
-    setIsDone(hour + minute > 0);
-  }, [alertBeforeRain, hourRef, minuteRef]);
+  const [time, setTime] = useState(() => alertBeforeRain);
 
   const { isFocused: isHourFocused, bind: hourBind } = useFocused();
   const { isFocused: isMinuteFocused, bind: minuteBind } = useFocused();
@@ -40,22 +36,12 @@ const AlertBefore = () => {
     () => isHourFocused || isMinuteFocused,
     [isHourFocused, isMinuteFocused]
   );
-
-  useEffect(() => {
-    if (isFocused) return;
-
-    const hour = Number(hourRef.current?.value);
-    const minute = Number(minuteRef.current?.value);
-    const value = hour * 60 + minute;
-    setIsDone(value > 0);
-  }, [isFocused]);
-
-  const percent = useSurveyProgressPercent(isDone);
+  const isDone = useMemo(() => time > 0 && !isFocused, [isFocused, time]);
 
   const [shouldTransition, setShouldTransition] = useState(false);
 
   useEffect(() => {
-    if (isDone) return;
+    if (alertBeforeRain) return;
 
     const timeoutID = setTimeout(() => {
       setShouldTransition(true);
@@ -66,25 +52,15 @@ const AlertBefore = () => {
   }, []);
 
   useEffect(() => {
-    if (!isDone) return;
+    setShouldTransition(isFocused);
+  }, [isFocused]);
 
-    const timeoutID = setTimeout(() => {
-      setShouldTransition(false);
-    }, 200);
-    return () => {
-      clearTimeout(timeoutID);
-    };
-  }, [isDone]);
+  const onClickNext = useCallback(() => {
+    setSurvey({ alertBeforeRain: time });
+    router.push("/survey/alert-summary/agreed");
+  }, [time]);
 
-  const { goToNextPage } = useNextSurvey();
-  const onClickNext = () => {
-    const hour = Number(hourRef.current?.value);
-    const minute = Number(minuteRef.current?.value);
-    const value = hour * 60 + minute;
-    setSurvey({ alertBeforeRain: value });
-
-    goToNextPage();
-  };
+  const percent = useSurveyProgressPercent(isDone);
 
   return (
     <main className="w-full flex flex-col min-h-screen">
@@ -98,6 +74,7 @@ const AlertBefore = () => {
         Top={<FadeTitle text="미리 알려 드릴게요" />}
         Bottom={
           <TimeInput
+            useTime={[time, setTime]}
             hourRef={hourRef}
             minuteRef={minuteRef}
             hourBind={hourBind}

--- a/src/app/survey/alert-summary/agree/page.tsx
+++ b/src/app/survey/alert-summary/agree/page.tsx
@@ -1,30 +1,19 @@
 "use client";
 
-import React, { useCallback, useEffect } from "react";
-
 import BackHeader from "@/components/header/BackHeader";
 import FadeTitle from "@/components/FadeTitle";
 import { LinearButton } from "@/components/button/LinearButton";
 import ProgressBar from "@/components/ProgressBar";
+import React from "react";
 import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import { surveyAtom } from "@/atom/survey";
 import { useAtom } from "jotai";
-import useNextSurvey from "@/hooks/survey/useNextSurvey";
+import { useRouter } from "next/navigation";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
 const AlertSummaryAgree = () => {
   const [{ isAgreedSummaryAlert }, setSurvey] = useAtom(surveyAtom);
-  const { goToNextPage } = useNextSurvey();
-
-  const getClickEvents = useCallback(
-    (agreed: boolean) => ({
-      onClick: () => {
-        setSurvey({ isAgreedSummaryAlert: agreed });
-      },
-      onRippleEndClick: goToNextPage
-    }),
-    [goToNextPage]
-  );
+  const router = useRouter();
 
   const percent = useSurveyProgressPercent(isAgreedSummaryAlert !== null);
 
@@ -39,10 +28,20 @@ const AlertSummaryAgree = () => {
         Top={<FadeTitle text={`요약 알림을\n받으시겠어요?`} />}
         Bottom={
           <div className="flex flex-row items-center gap-x-18pxr">
-            <LinearButton state="primary" {...getClickEvents(true)}>
+            <LinearButton
+              state="primary"
+              onClick={() => setSurvey({ isAgreedSummaryAlert: true })}
+              onRippleEndClick={() =>
+                router.push("/survey/alert-summary/select")
+              }
+            >
               네
             </LinearButton>
-            <LinearButton state="secondary" {...getClickEvents(false)}>
+            <LinearButton
+              state="secondary"
+              onClick={() => setSurvey({ isAgreedSummaryAlert: false })}
+              onRippleEndClick={() => router.push("/survey/time-period")}
+            >
               아니요
             </LinearButton>
           </div>

--- a/src/app/survey/alert-summary/agree/page.tsx
+++ b/src/app/survey/alert-summary/agree/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect } from "react";
 
 import BackHeader from "@/components/header/BackHeader";
 import FadeTitle from "@/components/FadeTitle";
@@ -8,32 +8,25 @@ import { LinearButton } from "@/components/button/LinearButton";
 import ProgressBar from "@/components/ProgressBar";
 import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import { surveyAtom } from "@/atom/survey";
-import { useRouter } from "next/navigation";
-import { useSetAtom } from "jotai";
+import { useAtom } from "jotai";
+import useNextSurvey from "@/hooks/survey/useNextSurvey";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
-const AlertSummaryAgreed = () => {
-  const [isAgreed, setIsAgreed] = useState<boolean | null>(null);
-  const setSurvey = useSetAtom(surveyAtom);
-  const router = useRouter();
+const AlertSummaryAgree = () => {
+  const [{ isAgreedSummaryAlert }, setSurvey] = useAtom(surveyAtom);
+  const { goToNextPage } = useNextSurvey();
 
   const getClickEvents = useCallback(
     (agreed: boolean) => ({
       onClick: () => {
-        setIsAgreed(agreed);
-
-        !agreed && setSurvey({ summaryAlertTime: 0 });
+        setSurvey({ isAgreedSummaryAlert: agreed });
       },
-      onRippleEndClick: () => {
-        router.push(
-          agreed ? "/survey/alert-summary/select" : "/survey/time-period"
-        );
-      }
+      onRippleEndClick: goToNextPage
     }),
-    []
+    [goToNextPage]
   );
 
-  const percent = useSurveyProgressPercent(isAgreed !== null);
+  const percent = useSurveyProgressPercent(isAgreedSummaryAlert !== null);
 
   return (
     <main className="min-h-screen w-full flex flex-col">
@@ -59,4 +52,4 @@ const AlertSummaryAgreed = () => {
   );
 };
 
-export default AlertSummaryAgreed;
+export default AlertSummaryAgree;

--- a/src/app/survey/alert-summary/agreed/page.tsx
+++ b/src/app/survey/alert-summary/agreed/page.tsx
@@ -1,28 +1,39 @@
 "use client";
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import BackHeader from "@/components/header/BackHeader";
 import FadeTitle from "@/components/FadeTitle";
 import { LinearButton } from "@/components/button/LinearButton";
 import ProgressBar from "@/components/ProgressBar";
 import TransitionTightSection from "@/components/layout/TransitionTightSection";
-import useNextSurvey from "@/hooks/survey/useNextSurvey";
+import { surveyAtom } from "@/atom/survey";
+import { useRouter } from "next/navigation";
+import { useSetAtom } from "jotai";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
-const AlertSummary = () => {
-  const [isDone, setIsDone] = useState(false);
+const AlertSummaryAgreed = () => {
+  const [isAgreed, setIsAgreed] = useState<boolean | null>(null);
+  const setSurvey = useSetAtom(surveyAtom);
+  const router = useRouter();
 
-  const { goToNextPage } = useNextSurvey();
+  const getClickEvents = useCallback(
+    (agreed: boolean) => ({
+      onClick: () => {
+        setIsAgreed(agreed);
 
-  const handleClick = useCallback((isAgree: boolean) => {
-    // setIsDone(true);
-    // setTimeout(() => {
-    //   goToNextPage();
-    // }, 500);
-  }, []);
+        !agreed && setSurvey({ summaryAlertTime: 0 });
+      },
+      onRippleEndClick: () => {
+        router.push(
+          agreed ? "/survey/alert-summary/select" : "/survey/time-period"
+        );
+      }
+    }),
+    []
+  );
 
-  const percent = useSurveyProgressPercent(isDone);
+  const percent = useSurveyProgressPercent(isAgreed !== null);
 
   return (
     <main className="min-h-screen w-full flex flex-col">
@@ -35,10 +46,10 @@ const AlertSummary = () => {
         Top={<FadeTitle text={`요약 알림을\n받으시겠어요?`} />}
         Bottom={
           <div className="flex flex-row items-center gap-x-18pxr">
-            <LinearButton state="primary" onClick={() => handleClick(true)}>
+            <LinearButton state="primary" {...getClickEvents(true)}>
               네
             </LinearButton>
-            <LinearButton state="secondary" onRippleEndClick={goToNextPage}>
+            <LinearButton state="secondary" {...getClickEvents(false)}>
               아니요
             </LinearButton>
           </div>
@@ -48,4 +59,4 @@ const AlertSummary = () => {
   );
 };
 
-export default AlertSummary;
+export default AlertSummaryAgreed;

--- a/src/app/survey/alert-summary/select/page.tsx
+++ b/src/app/survey/alert-summary/select/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+
+import BackHeader from "@/components/header/BackHeader";
+import FadeTitle from "@/components/FadeTitle";
+import FixedBottomBar from "@/components/bottombar/FixedBottomBar";
+import LargeInput from "@/components/input/LargeInput";
+import ProgressBar from "@/components/ProgressBar";
+import TransitionTightSection from "@/components/layout/TransitionTightSection";
+import { surveyAtom } from "@/atom/survey";
+import { useAtom } from "jotai";
+import useFocused from "@/hooks/useFocused";
+import { useRouter } from "next/navigation";
+import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
+
+const AlertSummarySelect = () => {
+  const timeRef = useRef<HTMLInputElement>(null);
+  const { isFocused, bind } = useFocused();
+  const [{ summaryAlertTime }, setSurvey] = useAtom(surveyAtom);
+  const [time, setTime] = useState(
+    summaryAlertTime ? String(summaryAlertTime) : ""
+  );
+
+  const [shouldTransition, setShouldTransition] = useState(false);
+
+  useEffect(() => {
+    if (summaryAlertTime) return;
+    const timeoutID = setTimeout(() => {
+      setShouldTransition(true);
+    }, 500);
+    return () => {
+      clearTimeout(timeoutID);
+    };
+  }, []);
+
+  useEffect(() => {
+    setShouldTransition(isFocused);
+  }, [isFocused]);
+
+  const router = useRouter();
+
+  const onClickNext = useCallback(() => {
+    setSurvey({ summaryAlertTime: parseInt(time) });
+
+    router.push("/survey/time-period");
+  }, [time]);
+
+  const isDone = useMemo(
+    () => !!parseInt(time) && !isFocused,
+    [isFocused, time]
+  );
+
+  const percent = useSurveyProgressPercent(isDone);
+
+  return (
+    <main className="min-h-screen w-full flex flex-col">
+      <BackHeader />
+      <section className="w-full px-12pxr">
+        <ProgressBar percent={percent} />
+      </section>
+      <TransitionTightSection
+        shouldTransition={shouldTransition}
+        Top={<FadeTitle text={`요약 알림을\n언제 받으시겠어요?`} />}
+        Bottom={
+          <div className="flex flex0row items-center gap-x-16pxr">
+            <LargeInput
+              ref={timeRef}
+              className="w-96pxr"
+              type="number"
+              inputMode="numeric"
+              maxLength={2}
+              placeholder="0"
+              pattern="[0-9]*"
+              value={time}
+              onChange={(e) => {
+                const value = e.target.value;
+
+                setTime(parseInt(value) > 24 ? "24" : value.slice(0, 2));
+
+                if (value.length === 2) {
+                  timeRef.current?.blur();
+                }
+              }}
+              {...bind}
+            />
+            <p className="text-white font-regular text-18pxr">시</p>
+          </div>
+        }
+      />
+      {isDone && (
+        <FixedBottomBar onRippleEndClick={onClickNext}>다음</FixedBottomBar>
+      )}
+    </main>
+  );
+};
+
+export default AlertSummarySelect;

--- a/src/app/survey/alert-summary/select/page.tsx
+++ b/src/app/survey/alert-summary/select/page.tsx
@@ -17,7 +17,7 @@ import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import { surveyAtom } from "@/atom/survey";
 import { useAtom } from "jotai";
 import useFocused from "@/hooks/useFocused";
-import { useRouter } from "next/navigation";
+import useNextSurvey from "@/hooks/survey/useNextSurvey";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
 const AlertSummarySelect = () => {
@@ -32,6 +32,7 @@ const AlertSummarySelect = () => {
 
   useEffect(() => {
     if (summaryAlertTime) return;
+
     const timeoutID = setTimeout(() => {
       setShouldTransition(true);
     }, 500);
@@ -44,13 +45,12 @@ const AlertSummarySelect = () => {
     setShouldTransition(isFocused);
   }, [isFocused]);
 
-  const router = useRouter();
+  const { goToNextPage } = useNextSurvey();
 
   const onClickNext = useCallback(() => {
     setSurvey({ summaryAlertTime: parseInt(time) });
-
-    router.push("/survey/time-period");
-  }, [time]);
+    goToNextPage();
+  }, [time, goToNextPage]);
 
   const isDone = useMemo(
     () => !!parseInt(time) && !isFocused,

--- a/src/app/survey/done/page.tsx
+++ b/src/app/survey/done/page.tsx
@@ -1,31 +1,71 @@
 "use client";
 
 import React, { useEffect, useMemo } from "react";
+import { SURVEY_INITIAL_STATE, surveyAtom } from "@/atom/survey";
+import { createUser, updateSurvey } from "@/api";
+import { useAtom, useAtomValue } from "jotai";
 
 import { DotLottiePlayer } from "@dotlottie/react-player";
+import { FCMTokenAtom } from "@/atom/webview";
 import FadeTitle from "@/components/FadeTitle";
-import { PAGE_TRANSITION_DURATION } from "@/constants/duration";
+import { StorageKey } from "@/constants/storage";
+import { Survey } from "@/api/type";
+import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
 const particleData = require("/public/particle.lottie");
-const isFirstUser = true;
+
 const Done = () => {
+  const [survey, setSurvey] = useAtom(surveyAtom);
   const router = useRouter();
-
-  useEffect(() => {
-    const timeoutID = setTimeout(() => {
-      router.push("/content");
-    }, PAGE_TRANSITION_DURATION);
-
-    return () => {
-      clearTimeout(timeoutID);
-    };
+  const userId = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem(StorageKey.UserId);
   }, []);
 
-  const titleText = useMemo(
-    () => (isFirstUser ? "환영합니다!" : "수정 완료!"),
-    [isFirstUser]
-  );
+  const {
+    mutate: _createUser,
+    status,
+    isPending: isCreating,
+    isSuccess: isCreatingSuccess
+  } = useMutation({
+    mutationFn: ({ survey }: { survey: Survey }) =>
+      createUser(survey, fcmToken),
+    onSuccess(data) {
+      setSurvey(SURVEY_INITIAL_STATE);
+      if (data.id) {
+        localStorage.setItem(StorageKey.UserId, `${data.id}`);
+      }
+      router.push("/content");
+    }
+  });
+
+  const { mutate: _updateSurvey, isPending: isUpdating } = useMutation({
+    mutationFn: (params: { survey: Survey; userId: string }) =>
+      updateSurvey(params.survey, params.userId),
+    onSuccess() {
+      router.push("/content");
+    }
+  });
+
+  const titleText = useMemo(() => {
+    if (isUpdating || isCreating) return "설정 중입니다..";
+    else if (isCreatingSuccess) return "환영합니다!";
+    return "수정 되었습니다!";
+  }, [isUpdating, isCreating, isCreatingSuccess]);
+
+  const fcmToken = useAtomValue(FCMTokenAtom);
+
+  useEffect(() => {
+    if (status !== "idle") return;
+    const { isAgreedSummaryAlert, ...restSurvey } = survey;
+    if (!userId) {
+      _createUser({ survey: restSurvey });
+    } else {
+      _updateSurvey({ survey: restSurvey, userId });
+    }
+  }, [status, survey, userId]);
+
   return (
     <main className="min-h-screen w-full flex items-center justify-center relative">
       <DotLottiePlayer

--- a/src/app/survey/time-period/page.tsx
+++ b/src/app/survey/time-period/page.tsx
@@ -16,10 +16,9 @@ import { useRouter } from "next/navigation";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
 const TimePeriod = () => {
-  const router = useRouter();
   const [shouldTransition, setShouldTransition] = useState(false);
   const [selectedPeriods, setSelectedPeriods] = useState<PeriodValueType[]>([]);
-  const [visibleButton, setVisibleButton] = useState(false);
+  const [visibleOptions, setVisibleOptions] = useState(false);
 
   useEffect(() => {
     const timeoutID = setTimeout(() => {
@@ -35,7 +34,7 @@ const TimePeriod = () => {
     if (!shouldTransition) return;
 
     const timeoutID = setTimeout(() => {
-      setVisibleButton(true);
+      setVisibleOptions(true);
     }, 500);
 
     return () => {
@@ -43,12 +42,12 @@ const TimePeriod = () => {
     };
   }, [shouldTransition]);
 
-  const isDispatchable = useMemo(
+  const isDone = useMemo(
     () => selectedPeriods.length > 0,
     [selectedPeriods.length]
   );
 
-  const percent = useSurveyProgressPercent(isDispatchable);
+  const percent = useSurveyProgressPercent(isDone);
   const { goToNextPage } = useNextPath();
 
   return (
@@ -61,7 +60,7 @@ const TimePeriod = () => {
         shouldTransition={shouldTransition}
         Top={<FadeTitle text="맞춰서 알려 드릴게요" />}
         Bottom={
-          visibleButton ? (
+          visibleOptions ? (
             <div className="w-full flex flex-col gap-y-18pxr mt-50pxr">
               {TIME_PERIODS.map(({ label, value, range }) => {
                 const startTime = range[0];
@@ -89,7 +88,7 @@ const TimePeriod = () => {
           ) : null
         }
       />
-      {isDispatchable && (
+      {isDone && (
         <FixedBottomBar onRippleEndClick={goToNextPage}>완료</FixedBottomBar>
       )}
     </main>

--- a/src/app/survey/time-period/page.tsx
+++ b/src/app/survey/time-period/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import BackHeader from "@/components/header/BackHeader";
 import CheckBox from "@/components/button/CheckBox";
@@ -11,12 +11,17 @@ import { PeriodValueType } from "@/types/survey";
 import ProgressBar from "@/components/ProgressBar";
 import { TIME_PERIODS } from "@/constants/survey";
 import TransitionTightSection from "@/components/layout/TransitionTightSection";
+import { surveyAtom } from "@/atom/survey";
+import { useAtom } from "jotai";
 import useNextPath from "@/hooks/survey/useNextSurvey";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
 const TimePeriod = () => {
   const [shouldTransition, setShouldTransition] = useState(false);
-  const [selectedPeriods, setSelectedPeriods] = useState<PeriodValueType[]>([]);
+  const [{ timePeriods }, setSurvey] = useAtom(surveyAtom);
+  const [selectedPeriods, setSelectedPeriods] = useState<PeriodValueType[]>(
+    timePeriods.length > 0 ? timePeriods : []
+  );
   const [visibleOptions, setVisibleOptions] = useState(false);
 
   useEffect(() => {
@@ -48,6 +53,11 @@ const TimePeriod = () => {
 
   const percent = useSurveyProgressPercent(isDone);
   const { goToNextPage } = useNextPath();
+
+  const onClickNext = useCallback(() => {
+    setSurvey({ timePeriods: selectedPeriods });
+    goToNextPage();
+  }, [goToNextPage, selectedPeriods]);
 
   return (
     <main className="min-h-screen w-full flex flex-col">
@@ -88,7 +98,7 @@ const TimePeriod = () => {
         }
       />
       {isDone && (
-        <FixedBottomBar onRippleEndClick={goToNextPage}>완료</FixedBottomBar>
+        <FixedBottomBar onRippleEndClick={onClickNext}>완료</FixedBottomBar>
       )}
     </main>
   );

--- a/src/app/survey/time-period/page.tsx
+++ b/src/app/survey/time-period/page.tsx
@@ -12,7 +12,6 @@ import ProgressBar from "@/components/ProgressBar";
 import { TIME_PERIODS } from "@/constants/survey";
 import TransitionTightSection from "@/components/layout/TransitionTightSection";
 import useNextPath from "@/hooks/survey/useNextSurvey";
-import { useRouter } from "next/navigation";
 import useSurveyProgressPercent from "@/hooks/survey/useSurveyProgressPercent";
 
 const TimePeriod = () => {

--- a/src/atom/survey.ts
+++ b/src/atom/survey.ts
@@ -5,7 +5,7 @@ const _surveyAtom = atom<Survey>({
   alertBeforeRain: 0,
   timePeriods: [],
   summaryAlertTime: 0,
-  isAgreedSummaryAlert: false
+  isAgreedSummaryAlert: null
 });
 
 export const surveyAtom = atom(

--- a/src/atom/survey.ts
+++ b/src/atom/survey.ts
@@ -4,7 +4,8 @@ import { atom } from "jotai";
 const _surveyAtom = atom<Survey>({
   alertBeforeRain: 0,
   timePeriods: [],
-  summaryAlertTime: 0
+  summaryAlertTime: 0,
+  isAgreedSummaryAlert: false
 });
 
 export const surveyAtom = atom(

--- a/src/atom/survey.ts
+++ b/src/atom/survey.ts
@@ -4,7 +4,7 @@ import { atom } from "jotai";
 const _surveyAtom = atom<Survey>({
   alertBeforeRain: 0,
   timePeriods: [],
-  summaryAlertTime: ""
+  summaryAlertTime: 0
 });
 
 export const surveyAtom = atom(

--- a/src/atom/survey.ts
+++ b/src/atom/survey.ts
@@ -1,16 +1,17 @@
-import { Survey } from "@/types/survey";
+import { SurveyState } from "@/types/survey";
 import { atom } from "jotai";
 
-const _surveyAtom = atom<Survey>({
+export const SURVEY_INITIAL_STATE = {
   alertBeforeRain: 0,
   timePeriods: [],
   summaryAlertTime: 0,
   isAgreedSummaryAlert: null
-});
+};
+const _surveyAtom = atom<SurveyState>(SURVEY_INITIAL_STATE);
 
 export const surveyAtom = atom(
   (get) => get(_surveyAtom),
-  (get, set, _survey: Partial<Survey>) => {
+  (get, set, _survey: Partial<SurveyState>) => {
     const survey = get(_surveyAtom);
     set(_surveyAtom, { ...survey, ..._survey });
   }

--- a/src/components/Webview.tsx
+++ b/src/components/Webview.tsx
@@ -5,11 +5,13 @@ import React, { ReactNode } from "react";
 import useSetCoordinates from "@/hooks/webview/useSetCoordinates";
 import useSetFCMToken from "@/hooks/webview/useSetFCMToken";
 import useSetPermissions from "@/hooks/webview/useSetPermissions";
+import useUpdateUserTokenMutation from "@/hooks/mutations/useUpdateUserTokenMutation";
 
 const Webview = ({ children }: { children: ReactNode }) => {
   useSetPermissions();
   useSetCoordinates();
   useSetFCMToken();
+  useUpdateUserTokenMutation();
 
   return <>{children}</>;
 };

--- a/src/components/input/TimeInput.tsx
+++ b/src/components/input/TimeInput.tsx
@@ -1,4 +1,10 @@
-import React, { RefObject } from "react";
+import React, {
+  Dispatch,
+  RefObject,
+  SetStateAction,
+  useEffect,
+  useState
+} from "react";
 
 import { FocusBind } from "@/hooks/useFocused";
 import LargeInput from "./LargeInput";
@@ -19,35 +25,44 @@ const TimeInput = ({
   hourRef,
   minuteRef,
   hourBind,
-  minuteBind
+  minuteBind,
+  useTime
 }: {
   hourBind: FocusBind;
   minuteBind: FocusBind;
   hourRef: RefObject<HTMLInputElement>;
   minuteRef: RefObject<HTMLInputElement>;
+  useTime: [number, Dispatch<SetStateAction<number>>];
 }) => {
+  const [time, setTime] = useTime;
+  const [hour, setHour] = useState(time ? String(Math.floor(time / 60)) : "");
+  const [minute, setMinute] = useState(time ? String(time % 60) : "");
+
+  useEffect(() => {
+    const hourNum = parseInt(hour);
+    const minuteNum = parseInt(minute);
+
+    if (isNaN(hourNum) || isNaN(minuteNum)) return;
+    setTime(hourNum * 60 + minuteNum);
+  }, [hour, minute]);
+
   return (
     <div className="flex flex-row items-center gap-x-16pxr">
       <LargeInput
         ref={hourRef}
         {...attributes}
+        value={hour}
         onChange={(e) => {
           const value = e.target.value;
 
-          const num = Number(value);
-          if (hourRef.current && num > 23) {
-            hourRef.current.value = "23";
-          }
+          setHour(parseInt(value) > 23 ? "23" : value.slice(0, 2));
 
           if (value.length === 2) {
-            hourRef.current?.blur();
-
-            if (!minuteRef.current?.value) {
+            if (!parseInt(minute)) {
               minuteRef.current?.focus();
+            } else {
+              hourRef.current?.blur();
             }
-          } else if (hourRef.current && value.length > 2) {
-            hourRef.current.value = value.slice(0, 2);
-            return;
           }
         }}
         {...hourBind}
@@ -57,19 +72,14 @@ const TimeInput = ({
         ref={minuteRef}
         {...attributes}
         max={60}
+        value={minute}
         onChange={(e) => {
           const value = e.target.value;
 
-          const num = Number(value);
-          if (minuteRef.current && num > 59) {
-            minuteRef.current.value = "59";
-          }
+          setMinute(parseInt(value) > 59 ? "59" : value.slice(0, 2));
 
-          if (e.target.value.length === 2) {
+          if (value.length === 2) {
             minuteRef.current?.blur();
-          } else if (minuteRef.current && e.target.value.length > 2) {
-            minuteRef.current.value = e.target.value.slice(0, 2);
-            return;
           }
         }}
         {...minuteBind}

--- a/src/components/input/TimeInput.tsx
+++ b/src/components/input/TimeInput.tsx
@@ -6,16 +6,7 @@ import LargeInput from "./LargeInput";
 const attributes = {
   className: "w-96pxr",
   type: "number",
-  inputMode: "numeric" as
-    | "search"
-    | "text"
-    | "none"
-    | "numeric"
-    | "email"
-    | "tel"
-    | "url"
-    | "decimal"
-    | undefined,
+  inputMode: "numeric" as "numeric",
   pattern: "[0-9]*",
   maxLength: 2,
   min: 0,

--- a/src/components/input/TimeInput.tsx
+++ b/src/components/input/TimeInput.tsx
@@ -42,8 +42,8 @@ const TimeInput = ({
     const hourNum = parseInt(hour);
     const minuteNum = parseInt(minute);
 
-    if (isNaN(hourNum) || isNaN(minuteNum)) return;
-    setTime(hourNum * 60 + minuteNum);
+    if (isNaN(hourNum)) return;
+    setTime(hourNum * 60 + (isNaN(minuteNum) ? 0 : minuteNum));
   }, [hour, minute]);
 
   return (

--- a/src/constants/survey.ts
+++ b/src/constants/survey.ts
@@ -12,4 +12,8 @@ export const TIME_PERIODS: {
   { label: "밤", value: "night", range: [21, 22, 23] }
 ];
 
-export const SURVEY_STEPS = ["alert-before", "alert-summary", "time-period"];
+export const SURVEY_STEPS = [
+  "alert-before",
+  "alert-summary/agreed",
+  "time-period"
+];

--- a/src/hooks/mutations/useUpdateSurveyMutation.ts
+++ b/src/hooks/mutations/useUpdateSurveyMutation.ts
@@ -1,0 +1,12 @@
+import { Survey } from "@/api/type";
+import { updateSurvey } from "@/api";
+import { useMutation } from "@tanstack/react-query";
+
+const useUpdateSurveyMutation = () => {
+  return useMutation({
+    mutationFn: ({ survey, userId }: { survey: Survey; userId: string }) =>
+      updateSurvey(survey, userId)
+  });
+};
+
+export default useUpdateSurveyMutation;

--- a/src/hooks/mutations/useUpdateUserTokenMutation.ts
+++ b/src/hooks/mutations/useUpdateUserTokenMutation.ts
@@ -1,0 +1,27 @@
+import { useEffect, useMemo } from "react";
+
+import { FCMTokenAtom } from "@/atom/webview";
+import { StorageKey } from "@/constants/storage";
+import { updateUserToken } from "@/api";
+import { useAtomValue } from "jotai";
+import { useMutation } from "@tanstack/react-query";
+
+const useUpdateUserTokenMutation = () => {
+  const fcmToken = useAtomValue(FCMTokenAtom);
+  const userId = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem(StorageKey.UserId);
+  }, []);
+
+  const { mutate } = useMutation({
+    mutationFn: ({ token, id }: { token: string; id: string }) =>
+      updateUserToken(token, id)
+  });
+
+  useEffect(() => {
+    if (!userId || !fcmToken) return;
+    mutate({ token: fcmToken, id: userId });
+  }, [userId, fcmToken]);
+};
+
+export default useUpdateUserTokenMutation;

--- a/src/hooks/survey/useNextSurvey.ts
+++ b/src/hooks/survey/useNextSurvey.ts
@@ -36,11 +36,11 @@ const useNextSurvey = () => {
       return SurveyPaths.Done;
     }
     return "/";
-  }, [pathname, survey]);
+  }, [pathname, survey.isAgreedSummaryAlert]);
 
   const goToNextPage = useCallback(() => {
     router.push(nextPath);
-  }, [nextPath]);
+  }, [nextPath, router]);
 
   return { goToNextPage };
 };

--- a/src/hooks/survey/useNextSurvey.ts
+++ b/src/hooks/survey/useNextSurvey.ts
@@ -1,20 +1,42 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
-import { SURVEY_STEPS } from "@/constants/survey";
+import { surveyAtom } from "@/atom/survey";
+import { useAtom } from "jotai";
+
+export enum SurveyPaths {
+  AlertBefore = "/survey/alert-before",
+  AlertSummaryAgree = "/survey/alert-summary/agree",
+  AlertSummarySelect = "/survey/alert-summary/select",
+  TimePeriod = "/survey/time-period",
+  Done = "/survey/done"
+}
 
 const useNextSurvey = () => {
+  const [survey, setSurvey] = useAtom(surveyAtom);
   const pathname = usePathname();
   const router = useRouter();
 
-  const nextPath = useMemo(() => {
-    const index = SURVEY_STEPS.findIndex((step) => pathname.includes(step));
+  useEffect(() => {
+    if (survey.isAgreedSummaryAlert) return;
 
-    if (index < 0) return "/";
-    return index === SURVEY_STEPS.length - 1
-      ? "/survey/done"
-      : SURVEY_STEPS[index + 1];
-  }, [pathname]);
+    setSurvey({ summaryAlertTime: 0 });
+  }, [survey.isAgreedSummaryAlert]);
+
+  const nextPath = useMemo(() => {
+    if (pathname.includes(SurveyPaths.AlertBefore)) {
+      return SurveyPaths.AlertSummaryAgree;
+    } else if (pathname.includes(SurveyPaths.AlertSummaryAgree)) {
+      return survey.isAgreedSummaryAlert
+        ? SurveyPaths.AlertSummarySelect
+        : SurveyPaths.TimePeriod;
+    } else if (pathname.includes(SurveyPaths.AlertSummarySelect)) {
+      return SurveyPaths.TimePeriod;
+    } else if (pathname.includes(SurveyPaths.TimePeriod)) {
+      return SurveyPaths.Done;
+    }
+    return "/";
+  }, [pathname, survey]);
 
   const goToNextPage = useCallback(() => {
     router.push(nextPath);

--- a/src/hooks/survey/useSurveyProgressPercent.ts
+++ b/src/hooks/survey/useSurveyProgressPercent.ts
@@ -1,26 +1,49 @@
-import React, { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
-import { SURVEY_STEPS } from "@/constants/survey";
+import { SurveyPaths } from "./useNextSurvey";
+import { surveyAtom } from "@/atom/survey";
+import { useAtomValue } from "jotai";
 import { usePathname } from "next/navigation";
 
-export const getSurveyProgressPercent = (path: string) => {
-  const index = SURVEY_STEPS.findIndex((step) => path.includes(step));
-  if (index < 0) return null;
-  const stepValue = 100 / SURVEY_STEPS.length - 1;
-  return {
-    start: stepValue * index,
-    end: index === SURVEY_STEPS.length - 1 ? 100 : stepValue * (index + 1)
-  };
-};
-
 const useSurveyProgressPercent = (isDone: boolean) => {
+  const survey = useAtomValue(surveyAtom);
+
   const pathname = usePathname();
 
+  const getSurveyProgressPercent = useCallback(() => {
+    const stepValue = 100 / 3;
+
+    if (pathname === SurveyPaths.AlertBefore) {
+      return {
+        start: 0,
+        end: stepValue
+      };
+    } else if (pathname === SurveyPaths.AlertSummaryAgree) {
+      return {
+        start: stepValue,
+        end: survey.isAgreedSummaryAlert
+          ? stepValue + stepValue / 2
+          : stepValue * 2
+      };
+    } else if (pathname === SurveyPaths.AlertSummarySelect) {
+      return {
+        start: stepValue + stepValue / 2,
+        end: stepValue * 2
+      };
+    } else if (pathname === SurveyPaths.TimePeriod) {
+      return {
+        start: stepValue * 2,
+        end: stepValue * 3
+      };
+    }
+    return null;
+  }, [pathname, survey.isAgreedSummaryAlert]);
+
   const percent = useMemo(() => {
-    const _percent = getSurveyProgressPercent(pathname);
+    const _percent = getSurveyProgressPercent();
     if (_percent === null) return 0;
     return !isDone ? _percent.start : _percent.end;
-  }, [isDone, pathname]);
+  }, [isDone, getSurveyProgressPercent]);
 
   return percent;
 };

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -10,5 +10,5 @@ export interface Survey {
   alertBeforeRain: number;
   timePeriods: PeriodValueType[];
   summaryAlertTime: number;
-  isAgreedSummaryAlert: boolean;
+  isAgreedSummaryAlert: boolean | null;
 }

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -6,7 +6,7 @@ export type PeriodValueType =
   | "evening"
   | "night";
 
-export interface Survey {
+export interface SurveyState {
   alertBeforeRain: number;
   timePeriods: PeriodValueType[];
   summaryAlertTime: number;

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -10,4 +10,5 @@ export interface Survey {
   alertBeforeRain: number;
   timePeriods: PeriodValueType[];
   summaryAlertTime: number;
+  isAgreedSummaryAlert: boolean;
 }

--- a/src/types/survey.ts
+++ b/src/types/survey.ts
@@ -9,5 +9,5 @@ export type PeriodValueType =
 export interface Survey {
   alertBeforeRain: number;
   timePeriods: PeriodValueType[];
-  summaryAlertTime: string;
+  summaryAlertTime: number;
 }


### PR DESCRIPTION
## Summary 

설문 연계 API 구현
- createUser (설문 생성 완료 시 유저 생성 POST)
- updateUserToken (fcmToken 변경 감지를 위함 PATCH)
- updateSurvey ( 설문 정보 변경 시 PUT )

survey 
- alert-summary 단일 라우팅 -> 요약 알림 동의 시 노출되는 조건 부 페이지 /alert-summary/select 페이지 구현, 관련 인터페이스 변경
- 설문 추가로 useSurveyProgressPercent, useSurveyNextpath 업데이트 

로컬 테스트 완료